### PR TITLE
Added menu button for mobile view

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2608,6 +2608,37 @@ section.separator-greenLine:before {
     }
 }
 
+.burgerMenuAndButtonContainer {
+    display: flex;
+    align-items: center;
+    gap: 32px;
+    margin-right: 32px;
+}
+
+.burgerMenu :hover{
+    cursor: pointer;
+    background-color: #048652;
+}
+
+.burgerList {
+    text-align: left;
+    position: absolute;
+    right: 0;
+    margin-top: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    background-color: #121212;
+    padding: 8px 12px 8px 4px;
+}
+
+.hideDesktopNav {}
+
+@media screen and (width > 767px) and (width < 1080px) {
+    .hideDesktopNav {
+        display: none;
+    }
+}
 
 
 

--- a/css/style.css
+++ b/css/style.css
@@ -2612,25 +2612,55 @@ section.separator-greenLine:before {
     display: flex;
     align-items: center;
     gap: 32px;
-    margin-right: 32px;
+    /* margin-right: 32px; */
 }
 
-.burgerMenu :hover{
-    cursor: pointer;
+.burgerMenu {
+    border: 2px solid;
+}
+
+.burgerMenu:hover{
     background-color: #048652;
+    cursor: pointer;
+}
+
+.burgerMenu.activeBurger {
+    background-color: red;
+}
+
+.burgerListWrapper {
+    display: none;
+}
+
+
+
+.showBurgerListWrapper {
+    display: block;
 }
 
 .burgerList {
     text-align: left;
+    list-style: none;
+    width: full;
     position: absolute;
+    margin-top: 20px;
     right: 0;
     margin-top: 20px;
     display: flex;
     flex-direction: column;
     gap: 8px;
     background-color: #121212;
-    padding: 8px 12px 8px 4px;
+    padding: 8px 12px 8px 8px;
+    user-select: none;
+    z-index: 9999;
 }
+
+
+.burgerList > *:hover {
+    color: rgb(128, 137, 148);
+    cursor: pointer;
+}
+
 
 .hideDesktopNav {}
 

--- a/css/style.css
+++ b/css/style.css
@@ -1940,10 +1940,10 @@ h4 svg {
 }
 
 @media screen and (max-width: 767px) {
-    .navbar-brand svg {
+    .navbar-brand {
         text-align: center;
         margin: 0 auto;
-        margin-top: -2px;
+        margin-top: -8px;
     }
 
 }
@@ -2622,6 +2622,7 @@ section.separator-greenLine:before {
 .burgerMenuContainer {
     position: relative;
     z-index: 9999;
+    display: block;
 }
 
 .burgerMenuContainer.activeBurgerContainer {
@@ -2718,21 +2719,18 @@ background-color: #121212;
     cursor: pointer;
 }
 
-@keyframes fadeIn {
-    from {
-      opacity: 0; /* Animation starts with opacity set to 0 */
-    }
-  
-    to {
-      opacity: 1; /* Animation ends with opacity set to 1 */
-    }
-  }
-
 
 .hideDesktopNav {}
 
-@media screen and (width > 767px) and (width < 1080px) {
+@media screen and (width > 767px) and (width <= 1080px) {
     .hideDesktopNav {
+        display: none;
+    }
+
+}
+
+@media screen and (width > 1080px) {
+    .burgerMenuContainer {
         display: none;
     }
 }

--- a/css/style.css
+++ b/css/style.css
@@ -294,7 +294,10 @@ table {
     margin-top: 3em;
 }
 
-
+.navbar {
+    padding-left: 16px;
+    padding-right: 16px;
+}
 
 .navbar-header {
     height: 77px;
@@ -2612,20 +2615,58 @@ section.separator-greenLine:before {
     display: flex;
     align-items: center;
     gap: 32px;
+    padding-top: 8px;
     /* margin-right: 32px; */
 }
 
-.burgerMenu {
-    border: 2px solid;
+.burgerMenuContainer {
+    position: relative;
+    z-index: 9999;
 }
 
+.burgerMenuContainer.activeBurgerContainer {
+    border: 2px solid #9e9e9e;
+    border-radius: 8px;
+    position: relative;
+    /* background-color: #008e51; */
+background-color: #121212;
+}
+
+.burgerMenuContainer.activeBurgerContainer .burgerMenu {
+    border: none;
+    border-bottom: 2px solid #9e9e9e;
+    border-radius: 0%;
+}
+
+.burgerMenu {
+    border: 2px solid #9e9e9e;
+    border-radius: 8px;
+    height: 52px;
+    user-select: none;
+}
+
+
 .burgerMenu:hover{
-    background-color: #048652;
+    /* background-color: #9e9e9e; */
+    color: #9e9e9e;
     cursor: pointer;
 }
 
+.burgerFlex {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    padding: 8px;
+    width: 140px;
+
+
+}
+
 .burgerMenu.activeBurger {
-    background-color: red;
+    /* background-color: #9e9e9e; */
+    color: #9e9e9e;
 }
 
 .burgerListWrapper {
@@ -2638,28 +2679,54 @@ section.separator-greenLine:before {
     display: block;
 }
 
+
 .burgerList {
     text-align: left;
     list-style: none;
     width: full;
-    position: absolute;
-    margin-top: 20px;
+    /* position: absolute; */
     right: 0;
-    margin-top: 20px;
+    margin-top: 4px;
     display: flex;
     flex-direction: column;
-    gap: 8px;
-    background-color: #121212;
+    /* gap: 16px; */
+    /* background-color: #121212; */
     padding: 8px 12px 8px 8px;
     user-select: none;
     z-index: 9999;
+    width: 140px;
 }
 
+.discordWrapper {
+    display: flex;
+    flex-direction: row;
+    justify-items: center;
+    align-items: center;
+    height:36px;
+    gap:12px;
+    margin-bottom: 4px;
+    margin-top: 4px;
+}
+
+.burgerList * {
+    padding-top: 12px;
+    padding-bottom: 12px;
+}
 
 .burgerList > *:hover {
     color: rgb(128, 137, 148);
     cursor: pointer;
 }
+
+@keyframes fadeIn {
+    from {
+      opacity: 0; /* Animation starts with opacity set to 0 */
+    }
+  
+    to {
+      opacity: 1; /* Animation ends with opacity set to 1 */
+    }
+  }
 
 
 .hideDesktopNav {}
@@ -3257,6 +3324,11 @@ iframe {
     margin-bottom: 52px;
 }
 
+.downloadButtonContainer {
+    padding-right: 180px;
+
+}
+
 .downloadButton {
     border: 2px solid #198652;
     border-radius: 5px;
@@ -3271,6 +3343,11 @@ iframe {
     margin-top: 9px;
     z-index: 500;
     background: #198652;
+    position: absolute;
+
+    width: 172px;
+    top: 14px;
+
 }
 
 

--- a/index.html
+++ b/index.html
@@ -129,15 +129,23 @@
                     <li><a href="http://discord.gg/vertcoin"><img src="./images/discord_grey.svg"></a></li>
                     </ul>
                     <div class="burgerMenuAndButtonContainer">
-                        <a class="downloadButton hideMobile" href="/download-wallet">Download Wallet</a>
-                        <div class="hideMobile">
+                        <div class="downloadButtonContainer">
+                            <a class="downloadButton hideMobile" href="/download-wallet">Download Wallet</a>
+                        </div>
+                    
+                        <div id="burgerMenuContainerScript" class="hideMobile burgerMenuContainer">
                             <div>
                                 <div id="burgerScript" class="burgerMenu">
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="bi bi-list"
-                                        viewBox="0 0 16 16">
-                                        <path fill-rule="evenodd"
-                                            d="M2.5 12a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5z" />
-                                    </svg>
+                                    <div class="burgerFlex">
+                                        <div>
+                                            Menu
+                                        </div>
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor"
+                                            class="bi bi-list" viewBox="0 0 16 16">
+                                            <path fill-rule="evenodd"
+                                                d="M2.5 12a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5z" />
+                                        </svg>
+                                    </div>
                                 </div>
                                 <div class="burgerListWrapper">
                                     <div class="burgerList">
@@ -145,6 +153,10 @@
                                         <div>Bitcoin Comparison</div>
                                         <div>Community</div>
                                         <div>Specifications</div>
+                                        <div class="discordWrapper">
+                                            <div><img src="./images/discord_grey.svg" /></div>
+                                            <div>Discord</div>
+                                        </div>
                                     </div>
                                 </div>
                             </div>
@@ -157,10 +169,12 @@
             <script>
                 const burgerMenu = document.getElementById('burgerScript');
                 const burgerList = document.querySelector('.burgerListWrapper');
+                const burgerContainer = document.getElementById('burgerMenuContainerScript');
 
                 burgerMenu.addEventListener('click', function() {
                     burgerList.classList.toggle('showBurgerListWrapper');
                     burgerMenu.classList.toggle('activeBurger');
+                    burgerContainer.classList.toggle('activeBurgerContainer');
                     });
             </script>
 

--- a/index.html
+++ b/index.html
@@ -123,44 +123,42 @@
 
             </div>
             <div>
-                <ul class="mobileNav hideDesktop">
-                    <li><a href="./mining-setup/">Mining Setup</a></li>
-                    <li><a href="./community/">Community</a></li>
-                    <li><a href="http://discord.gg/vertcoin"><img src="./images/discord_grey.svg"></a></li>
-                    </ul>
-                    <div class="burgerMenuAndButtonContainer">
-                        <div class="downloadButtonContainer">
-                            <a class="downloadButton hideMobile" href="/download-wallet">Download Wallet</a>
-                        </div>
-                    
-                        <div id="burgerMenuContainerScript" class="hideMobile burgerMenuContainer">
-                            <div>
-                                <div id="burgerScript" class="burgerMenu">
-                                    <div class="burgerFlex">
-                                        <div>
-                                            Menu
-                                        </div>
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor"
-                                            class="bi bi-list" viewBox="0 0 16 16">
-                                            <path fill-rule="evenodd"
-                                                d="M2.5 12a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5z" />
-                                        </svg>
-                                    </div>
+                <!-- <ul class="mobileNav hideDesktop">
+                                <li><a href="./mining-setup/">Mining Setup</a></li>
+                                <li><a href="./community/">Community</a></li>
+                                <li><a href="http://discord.gg/vertcoin"><img src="./images/discord_grey.svg"></a></li>
+                                </ul> -->
+                <div class="burgerMenuAndButtonContainer">
+                    <div class="downloadButtonContainer">
+                        <a class="downloadButton hideMobile" href="/download-wallet">Download Wallet</a>
+                    </div>
+            
+                    <div id="burgerMenuContainerScript" class=" burgerMenuContainer">
+                        <div id="burgerScript" class="burgerMenu">
+                            <div class="burgerFlex">
+                                <div>
+                                    Menu
                                 </div>
-                                <div class="burgerListWrapper">
-                                    <div class="burgerList">
-                                        <div>Mining Setup</div>
-                                        <div>Bitcoin Comparison</div>
-                                        <div>Community</div>
-                                        <div>Specifications</div>
-                                        <div class="discordWrapper">
-                                            <div><img src="./images/discord_grey.svg" /></div>
-                                            <div>Discord</div>
-                                        </div>
-                                    </div>
-                                </div>
+                                <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor"
+                                    class="bi bi-list" viewBox="0 0 16 16">
+                                    <path fill-rule="evenodd"
+                                        d="M2.5 12a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5z" />
+                                </svg>
                             </div>
                         </div>
+                        <div class="burgerListWrapper">
+                            <div class="burgerList">
+                                <a href="./mining-setup/">Mining Setup</a>
+                                <a href="./bitcoin-vs-vertcoin">Bitcoin Comparison</a>
+                                <a href="./community/">Community</a>
+                                <a href="./specs-explained">Specifications</a>
+                                <a class="discordWrapper" href="http://discord.gg/vertcoin">
+                                    <div><img src="./images/discord_grey.svg" /></div>
+                                    <div>Discord</div>
+                                </a>
+                            </div>
+                        </div>
+                    </div>
                 </div>
                 </nav>
             

--- a/index.html
+++ b/index.html
@@ -33,14 +33,14 @@
 
 
     
-    <link rel="stylesheet" href="/css/bootstrap.css">
+    <link rel="stylesheet" href="./css/bootstrap.css">
 
     
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,800&amp;subset=cyrillic,cyrillic-ext" rel="stylesheet">
 
 
 
-    <link rel="stylesheet" href="/css/style.css">
+    <link rel="stylesheet" href="./css/style.css">
 
 
     
@@ -59,7 +59,7 @@
                 
                 
                 <a class="navbar-brand hideDesktop" href="/">
-                    <img src="../images/vertcoin.png">
+                    <img src="./images/vertcoin.png">
                 </a>
                 <a class="navbar-brand hideMobile" href="/">
 
@@ -104,15 +104,15 @@
                     </svg></a>
                 <a class="js-fh5co-nav-toggle fh5co-language-toggle" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar"><i></i></a>
             </div>
-            <div id="navbar" class="navbar-collapse collapse">
-                <ul class="nav navbar-nav mainNav hideMobile">
+            <div id="navbar" class="navbar-collapse collapse ">
+                <ul class="nav navbar-nav mainNav hideMobile hideDesktopNav">
 
                     
-                    <li><a href="../mining-setup">Mining Setup</a></li>
-                    <li><a href="../bitcoin-vs-vertcoin">Bitcoin Comparison</a></li>
+                    <li><a href="./mining-setup">Mining Setup</a></li>
+                    <li><a href="./bitcoin-vs-vertcoin">Bitcoin Comparison</a></li>
 
-                    <li><a href="../community">Community</a></li>
-                    <li><a href="../specs-explained">Specifications</a></li>
+                    <li><a href="./community">Community</a></li>
+                    <li><a href="./specs-explained">Specifications</a></li>
 
 
 
@@ -124,14 +124,33 @@
             </div>
             <div>
                 <ul class="mobileNav hideDesktop">
-                    <li><a href="../mining-setup/">Mining Setup</a></li>
-                    <li><a href="../community/">Community</a></li>
-                    <li><a href="http://discord.gg/vertcoin"><img src="../images/discord_grey.svg"></a></li>
-                </ul>
-                <a class="downloadButton hideMobile" href="/download-wallet">Download Wallet</a>
-        </nav>
-        
-    </div>
+                    <li><a href="./mining-setup/">Mining Setup</a></li>
+                    <li><a href="./community/">Community</a></li>
+                    <li><a href="http://discord.gg/vertcoin"><img src="./images/discord_grey.svg"></a></li>
+                    </ul>
+                    <div class="burgerMenuAndButtonContainer">
+                        <a class="downloadButton hideMobile" href="/download-wallet">Download Wallet</a>
+                        <div class="hideMobile">
+                            <div>
+                                <div class="burgerMenu">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="bi bi-list"
+                                    viewBox="0 0 16 16">
+                                    <path fill-rule="evenodd"
+                                        d="M2.5 12a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5z" />
+                                </svg>
+                            </div>
+                                <div class="burgerList">
+                                    <div>Mining Setup</div>
+                                    <div>Bitcoin Comparison</div>
+                                    <div>Community</div>
+                                    <div>Specifications</div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    </nav>
+                
+                </div>
 </header>
 <div class="separator-greenLine"> <section id="home-why" data-section="home-why">
 

--- a/index.html
+++ b/index.html
@@ -132,25 +132,38 @@
                         <a class="downloadButton hideMobile" href="/download-wallet">Download Wallet</a>
                         <div class="hideMobile">
                             <div>
-                                <div class="burgerMenu">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="bi bi-list"
-                                    viewBox="0 0 16 16">
-                                    <path fill-rule="evenodd"
-                                        d="M2.5 12a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5z" />
-                                </svg>
-                            </div>
-                                <div class="burgerList">
-                                    <div>Mining Setup</div>
-                                    <div>Bitcoin Comparison</div>
-                                    <div>Community</div>
-                                    <div>Specifications</div>
+                                <div id="burgerScript" class="burgerMenu">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="bi bi-list"
+                                        viewBox="0 0 16 16">
+                                        <path fill-rule="evenodd"
+                                            d="M2.5 12a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5z" />
+                                    </svg>
+                                </div>
+                                <div class="burgerListWrapper">
+                                    <div class="burgerList">
+                                        <div>Mining Setup</div>
+                                        <div>Bitcoin Comparison</div>
+                                        <div>Community</div>
+                                        <div>Specifications</div>
+                                    </div>
                                 </div>
                             </div>
                         </div>
-                    </div>
-                    </nav>
-                
                 </div>
+                </nav>
+            
+            </div>
+
+            <script>
+                const burgerMenu = document.getElementById('burgerScript');
+                const burgerList = document.querySelector('.burgerListWrapper');
+
+                burgerMenu.addEventListener('click', function() {
+                    burgerList.classList.toggle('showBurgerListWrapper');
+                    burgerMenu.classList.toggle('activeBurger');
+                    });
+            </script>
+
 </header>
 <div class="separator-greenLine"> <section id="home-why" data-section="home-why">
 

--- a/index.html
+++ b/index.html
@@ -33,14 +33,14 @@
 
 
     
-    <link rel="stylesheet" href="./css/bootstrap.css">
+    <link rel="stylesheet" href="/css/bootstrap.css">
 
     
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,800&amp;subset=cyrillic,cyrillic-ext" rel="stylesheet">
 
 
 
-    <link rel="stylesheet" href="./css/style.css">
+    <link rel="stylesheet" href="/css/style.css">
 
 
     
@@ -59,7 +59,7 @@
                 
                 
                 <a class="navbar-brand hideDesktop" href="/">
-                    <img src="./images/vertcoin.png">
+                    <img src="../images/vertcoin.png">
                 </a>
                 <a class="navbar-brand hideMobile" href="/">
 
@@ -108,11 +108,11 @@
                 <ul class="nav navbar-nav mainNav hideMobile hideDesktopNav">
 
                     
-                    <li><a href="./mining-setup">Mining Setup</a></li>
-                    <li><a href="./bitcoin-vs-vertcoin">Bitcoin Comparison</a></li>
+                    <li><a href="../mining-setup">Mining Setup</a></li>
+                    <li><a href="../bitcoin-vs-vertcoin">Bitcoin Comparison</a></li>
 
-                    <li><a href="./community">Community</a></li>
-                    <li><a href="./specs-explained">Specifications</a></li>
+                    <li><a href="../community">Community</a></li>
+                    <li><a href="../specs-explained">Specifications</a></li>
 
 
 
@@ -126,7 +126,7 @@
                 <!-- <ul class="mobileNav hideDesktop">
                                 <li><a href="./mining-setup/">Mining Setup</a></li>
                                 <li><a href="./community/">Community</a></li>
-                                <li><a href="http://discord.gg/vertcoin"><img src="./images/discord_grey.svg"></a></li>
+                                <li><a href="http://discord.gg/vertcoin"><img src="../images/discord_grey.svg"></a></li>
                                 </ul> -->
                 <div class="burgerMenuAndButtonContainer">
                     <div class="downloadButtonContainer">
@@ -148,12 +148,12 @@
                         </div>
                         <div class="burgerListWrapper">
                             <div class="burgerList">
-                                <a href="./mining-setup/">Mining Setup</a>
-                                <a href="./bitcoin-vs-vertcoin">Bitcoin Comparison</a>
-                                <a href="./community/">Community</a>
-                                <a href="./specs-explained">Specifications</a>
+                                <a href="../mining-setup/">Mining Setup</a>
+                                <a href="../bitcoin-vs-vertcoin">Bitcoin Comparison</a>
+                                <a href="../community/">Community</a>
+                                <a href="../specs-explained">Specifications</a>
                                 <a class="discordWrapper" href="http://discord.gg/vertcoin">
-                                    <div><img src="./images/discord_grey.svg" /></div>
+                                    <div><img src="../images/discord_grey.svg" /></div>
                                     <div>Discord</div>
                                 </a>
                             </div>


### PR DESCRIPTION
Replaced mobile top-navbar page list with menu button. For desktop, menu button shows when Download Wallet button is about to clip over the page list.
Added some padding to desktop top-navbar. 
Moved mobile top-navbar vtc logo up a bit to align with button.

Functionality worked on my end when I changed file directories for my local env.