### PR TITLE
fixed vtc logo sizing for mobile navbar

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -327,6 +327,7 @@ table {
         /*color: #048657 !important;*/
         padding-top: 0px;
         padding-right: 0px;
+        position: absolute;
     }
 
 


### PR DESCRIPTION
Fixed problem where VTC logo on the top left was squished for mobile users but not for desktop